### PR TITLE
Adding new table to display iptables filters, chains and rules

### DIFF
--- a/osquery/tables/networking/tests/iptables_tests.cpp
+++ b/osquery/tables/networking/tests/iptables_tests.cpp
@@ -64,9 +64,3 @@ TEST_F(IptablesTests, test_iptables_ip_entry) {
 }
 }
 }
-
-int main(int argc, char* argv[]) {
-  testing::InitGoogleTest(&argc, argv);
-  google::InitGoogleLogging(argv[0]);
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
Refer to PR #1060 for details.

This code gives osquery visibility over iptables filter, chains and rules. Also the headers that are patched to make osquery to compile with a C++ compiler but the returns has a void pointer. More info: https://bugzilla.netfilter.org/show_bug.cgi?id=536
